### PR TITLE
カテゴリの追加

### DIFF
--- a/client/pages/sightseeingMap/index.page.tsx
+++ b/client/pages/sightseeingMap/index.page.tsx
@@ -12,6 +12,9 @@ const destinationSpots: TravelSpot[] = [
       longitude: 139.8804,
     },
     description: '日本で一番楽しい場所',
+    categories: {
+      '観光・遊ぶ': ['テーマパーク'],
+    },
   },
   {
     name: '東京スカイツリー',
@@ -20,6 +23,9 @@ const destinationSpots: TravelSpot[] = [
       longitude: 139.810833,
     },
     description: '日本で一番高い建物',
+    categories: {
+      '観光・遊ぶ': ['名所・史跡'],
+    },
   },
   {
     name: '東京タワー',
@@ -28,6 +34,9 @@ const destinationSpots: TravelSpot[] = [
       longitude: 139.745556,
     },
     description: '日本で一番有名な観光地',
+    categories: {
+      '観光・遊ぶ': ['名所・史跡'],
+    },
   },
   {
     name: '赤羽',
@@ -36,6 +45,9 @@ const destinationSpots: TravelSpot[] = [
       longitude: 139.720556,
     },
     description: '日本で一番美味しいラーメン',
+    categories: {
+      'グルメ・レストラン': [],
+    },
   },
 ];
 

--- a/client/pages/sightseeingMap/index.page.tsx
+++ b/client/pages/sightseeingMap/index.page.tsx
@@ -12,9 +12,7 @@ const destinationSpots: TravelSpot[] = [
       longitude: 139.8804,
     },
     description: '日本で一番楽しい場所',
-    categories: {
-      '観光・遊ぶ': ['テーマパーク'],
-    },
+    categories: 'テーマパーク',
   },
   {
     name: '東京スカイツリー',
@@ -23,9 +21,7 @@ const destinationSpots: TravelSpot[] = [
       longitude: 139.810833,
     },
     description: '日本で一番高い建物',
-    categories: {
-      '観光・遊ぶ': ['名所・史跡'],
-    },
+    categories: '名所・史跡',
   },
   {
     name: '東京タワー',
@@ -34,9 +30,7 @@ const destinationSpots: TravelSpot[] = [
       longitude: 139.745556,
     },
     description: '日本で一番有名な観光地',
-    categories: {
-      '観光・遊ぶ': ['名所・史跡'],
-    },
+    categories: '名所・史跡',
   },
   {
     name: '赤羽',
@@ -45,9 +39,7 @@ const destinationSpots: TravelSpot[] = [
       longitude: 139.720556,
     },
     description: '日本で一番美味しいラーメン',
-    categories: {
-      'グルメ・レストラン': [],
-    },
+    categories: 'グルメ・レストラン',
   },
 ];
 

--- a/client/pages/travelDestination/index.module.css
+++ b/client/pages/travelDestination/index.module.css
@@ -54,7 +54,7 @@
   margin: 15px;
 }
 
-.serch {
+.search {
   width: 100px;
   height: 30px;
   color: white;
@@ -62,7 +62,7 @@
   border: 0;
 }
 
-.serch:hover {
+.search:hover {
   background-color: #ff5700;
 }
 

--- a/client/pages/travelDestination/index.page.tsx
+++ b/client/pages/travelDestination/index.page.tsx
@@ -13,7 +13,6 @@ const TravelDestination = () => {
       body: { destination: userDestination },
     });
     setTravelSpots(res);
-    console.log(travelSpots.map((spot) => spot.categories));
   };
 
   return (

--- a/client/pages/travelDestination/index.page.tsx
+++ b/client/pages/travelDestination/index.page.tsx
@@ -13,6 +13,7 @@ const TravelDestination = () => {
       body: { destination: userDestination },
     });
     setTravelSpots(res);
+    console.log(travelSpots.map((spot) => spot.categories));
   };
 
   return (
@@ -47,7 +48,7 @@ const TravelDestination = () => {
         />
       </div>
       <input value={userDestination} onChange={(e) => setUserDestination(e.target.value)} />
-      <button onClick={fetchTravelSpots} className={styles.serch}>
+      <button onClick={fetchTravelSpots} className={styles.search}>
         検索
       </button>
       <ul>
@@ -56,6 +57,16 @@ const TravelDestination = () => {
             <h2 className={styles.listTitle}>名前：{spot.name}</h2>
             <p className={styles.listDescription}>概要：{spot.description}</p>
             <br />
+            {Object.entries(spot.categories).map(([mainCategory, subCategories]) => (
+              <div key={mainCategory}>
+                <h4>{mainCategory}</h4>
+                <ul>
+                  {subCategories.map((subCategory) => (
+                    <li key={subCategory}>{subCategory}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
             <p className={styles.listDescription}>
               緯度:{spot.location.latitude}、経度:{spot.location.longitude}
             </p>

--- a/client/pages/travelDestination/index.page.tsx
+++ b/client/pages/travelDestination/index.page.tsx
@@ -13,6 +13,7 @@ const TravelDestination = () => {
       body: { destination: userDestination },
     });
     setTravelSpots(res);
+    console.log(travelSpots.map((spot) => spot.categories));
   };
 
   return (

--- a/client/pages/travelDestination/index.page.tsx
+++ b/client/pages/travelDestination/index.page.tsx
@@ -46,7 +46,6 @@ const TravelDestination = () => {
           placeholder="例:京都"
         />
       </div>
-      <input value={userDestination} onChange={(e) => setUserDestination(e.target.value)} />
       <button onClick={fetchTravelSpots} className={styles.search}>
         検索
       </button>

--- a/client/pages/travelDestination/index.page.tsx
+++ b/client/pages/travelDestination/index.page.tsx
@@ -56,16 +56,7 @@ const TravelDestination = () => {
             <h2 className={styles.listTitle}>名前：{spot.name}</h2>
             <p className={styles.listDescription}>概要：{spot.description}</p>
             <br />
-            {Object.entries(spot.categories).map(([mainCategory, subCategories]) => (
-              <div key={mainCategory}>
-                <h4>{mainCategory}</h4>
-                <ul>
-                  {subCategories.map((subCategory) => (
-                    <li key={subCategory}>{subCategory}</li>
-                  ))}
-                </ul>
-              </div>
-            ))}
+            <p className={styles.listDescription}>カテゴリ：{spot.categories}</p>
             <p className={styles.listDescription}>
               緯度:{spot.location.latitude}、経度:{spot.location.longitude}
             </p>

--- a/server/common/types/travelSpots.ts
+++ b/server/common/types/travelSpots.ts
@@ -7,5 +7,5 @@ export type TravelSpot = {
   name: string;
   location: LatAndLng;
   description: string;
-  categories: Record<string, string[]>;
+  categories: string;
 };

--- a/server/common/types/travelSpots.ts
+++ b/server/common/types/travelSpots.ts
@@ -7,4 +7,5 @@ export type TravelSpot = {
   name: string;
   location: LatAndLng;
   description: string;
+  categories: Record<string, string[]>;
 };

--- a/server/domain/travelSpot/service/coordinateService.ts
+++ b/server/domain/travelSpot/service/coordinateService.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import type { LatAndLng } from 'common/types/travelSpots';
+export const fetchCoordinates = async (address: string): Promise<LatAndLng | null> => {
+  try {
+    const encodedAddress = encodeURIComponent(address);
+    const url = `https://msearch.gsi.go.jp/address-search/AddressSearch?q=${encodedAddress}`;
+    const response = await axios.get(url);
+    const data = response.data;
+
+    if (data && data.length > 0) {
+      const { geometry } = data[0];
+      const { coordinates } = geometry;
+      const [lng, lat] = coordinates;
+      return { latitude: lat, longitude: lng };
+    } else {
+      console.error('No coordinates found for address:', address);
+      return null;
+    }
+  } catch (error) {
+    console.error('Error fetching coordinates:', error);
+    return null;
+  }
+};

--- a/server/domain/travelSpot/service/travelSpotDataExtractor.ts
+++ b/server/domain/travelSpot/service/travelSpotDataExtractor.ts
@@ -1,0 +1,26 @@
+import type { CheerioAPI } from 'cheerio';
+
+export const extractTravelSpotData = ($: CheerioAPI): { url: string; category: string }[] => {
+  const travelURLData: { url: string; category: string }[] = [];
+  $('#main > div.search_result > div.item.spot_list > ul > li').each((index, element) => {
+    const href = $(element).find('p > a').attr('href');
+    const categoryNodes = $(element)
+      .find('div > div > div.txt > p.category')
+      .contents()
+      .filter(function () {
+        return this.nodeType === 3;
+      });
+
+    const categories = categoryNodes
+      .map(function () {
+        return $(this).text().trim();
+      })
+      .get()
+      .join(',');
+
+    if (href) {
+      travelURLData.push({ url: href, category: categories });
+    }
+  });
+  return travelURLData;
+};

--- a/server/domain/travelSpot/service/travelSpotService.ts
+++ b/server/domain/travelSpot/service/travelSpotService.ts
@@ -1,31 +1,13 @@
 import axios from 'axios';
 import type { CheerioAPI } from 'cheerio';
 import cheerio from 'cheerio';
-import type { LatAndLng, TravelSpot } from 'common/types/travelSpots';
+import type { TravelSpot } from 'common/types/travelSpots';
+import { fetchCoordinates } from './coordinateService';
 
-const fetchCoordinates = async (address: string): Promise<LatAndLng | null> => {
-  try {
-    const encodedAddress = encodeURIComponent(address);
-    const url = `https://msearch.gsi.go.jp/address-search/AddressSearch?q=${encodedAddress}`;
-    const response = await axios.get(url);
-    const data = response.data;
-
-    if (data && data.length > 0) {
-      const { geometry } = data[0];
-      const { coordinates } = geometry;
-      const [lng, lat] = coordinates;
-      return { latitude: lat, longitude: lng };
-    } else {
-      console.error('No coordinates found for address:', address);
-      return null;
-    }
-  } catch (error) {
-    console.error('Error fetching coordinates:', error);
-    return null;
-  }
-};
-
-export const fetchTravelSpotDetails = async (url: string): Promise<TravelSpot | null> => {
+export const getTravelSpotDetails = async (
+  url: string,
+  category: string,
+): Promise<TravelSpot | null> => {
   try {
     const { data } = await axios.get(url);
     const $: CheerioAPI = cheerio.load(data);
@@ -50,31 +32,6 @@ export const fetchTravelSpotDetails = async (url: string): Promise<TravelSpot | 
 
     const coordinates = await fetchCoordinates(address);
 
-    // カテゴリ情報をオブジェクトとして格納
-    const categories: Record<string, string[]> = {};
-
-    $(
-      '#main_container > main > div.shisetsu_contentBody > div > section > div > div.shisetsu_informationList > dl',
-    ).each((index, element) => {
-      const dtText = $(element).find('dt').text().trim();
-      if (dtText.includes('カテゴリ')) {
-        $(element)
-          .find('dd > ol')
-          .each((_, olElement) => {
-            const mainCategory = $(olElement).find('li:nth-child(1) > a').text().trim();
-            const subCategory = $(olElement).find('li:nth-child(2) > a').text().trim();
-            if (mainCategory) {
-              if (!categories[mainCategory]) {
-                categories[mainCategory] = [];
-              }
-              if (subCategory && !categories[mainCategory].includes(subCategory)) {
-                categories[mainCategory].push(subCategory);
-              }
-            }
-          });
-      }
-    });
-
     if (coordinates) {
       return {
         name,
@@ -83,7 +40,7 @@ export const fetchTravelSpotDetails = async (url: string): Promise<TravelSpot | 
           longitude: coordinates.longitude,
         },
         description,
-        categories,
+        categories: category,
       };
     } else {
       return {
@@ -93,24 +50,11 @@ export const fetchTravelSpotDetails = async (url: string): Promise<TravelSpot | 
           longitude: 0,
         },
         description,
-        categories,
+        categories: category,
       };
     }
   } catch (error) {
     console.error('Error fetching travel spot details:', error);
     return null;
   }
-};
-
-export const extractTravelSpotLinks = ($: CheerioAPI): string[] => {
-  const travelURLs: string[] = [];
-  $('#main > div.search_result > div.item.spot_list > ul > li > p > a ').each((index, element) => {
-    if (index < 3) {
-      const href = $(element).attr('href');
-      if (href) {
-        travelURLs.push(href);
-      }
-    }
-  });
-  return travelURLs;
 };

--- a/server/domain/travelSpot/service/travelSpotService.ts
+++ b/server/domain/travelSpot/service/travelSpotService.ts
@@ -50,6 +50,31 @@ export const fetchTravelSpotDetails = async (url: string): Promise<TravelSpot | 
 
     const coordinates = await fetchCoordinates(address);
 
+    // カテゴリ情報をオブジェクトとして格納
+    const categories: Record<string, string[]> = {};
+
+    $(
+      '#main_container > main > div.shisetsu_contentBody > div > section > div > div.shisetsu_informationList > dl',
+    ).each((index, element) => {
+      const dtText = $(element).find('dt').text().trim();
+      if (dtText.includes('カテゴリ')) {
+        $(element)
+          .find('dd > ol')
+          .each((_, olElement) => {
+            const mainCategory = $(olElement).find('li:nth-child(1) > a').text().trim();
+            const subCategory = $(olElement).find('li:nth-child(2) > a').text().trim();
+            if (mainCategory) {
+              if (!categories[mainCategory]) {
+                categories[mainCategory] = [];
+              }
+              if (subCategory && !categories[mainCategory].includes(subCategory)) {
+                categories[mainCategory].push(subCategory);
+              }
+            }
+          });
+      }
+    });
+
     if (coordinates) {
       return {
         name,
@@ -58,6 +83,7 @@ export const fetchTravelSpotDetails = async (url: string): Promise<TravelSpot | 
           longitude: coordinates.longitude,
         },
         description,
+        categories,
       };
     } else {
       return {
@@ -67,6 +93,7 @@ export const fetchTravelSpotDetails = async (url: string): Promise<TravelSpot | 
           longitude: 0,
         },
         description,
+        categories,
       };
     }
   } catch (error) {


### PR DESCRIPTION
## 内容
メインカテゴリー、サブカテゴリを追加
スクレイピングする際にエリア検索で出なかったらキーワード検索を実行


## 変更点

1. TravelSpotの型情報にcategoriesを追加
2. スクレイピングの際にエリア検索を行っても要素がない場合キーワード検索を実行するようにした
3. スペルミスを直した
4. ダミーデータにカテゴリを追加

## 関連 Issue

## スクリーンショット・動画など
<img width="743" alt="スクリーンショット 2024-07-17 2 57 11" src="https://github.com/user-attachments/assets/c44f39cb-8c7e-4a06-9c58-8fb892e3622f">



## その他
