### PR TITLE
ページによって出すボタンの種類を変えるように

### DIFF
--- a/client/components/selectedTravelSpots/SelectedTravelSpots.module.css
+++ b/client/components/selectedTravelSpots/SelectedTravelSpots.module.css
@@ -46,6 +46,12 @@
   gap: 5px;
 }
 
+.backButton {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
 .button {
   width: 100%;
   color: #fff;
@@ -57,6 +63,10 @@
 @media screen and (width <= 800px) {
   .buttonGroup {
     flex-direction: row;
+  }
+
+  .backButton {
+    align-items: center;
   }
 
   .button {

--- a/client/components/selectedTravelSpots/SelectedTravelSpots.tsx
+++ b/client/components/selectedTravelSpots/SelectedTravelSpots.tsx
@@ -10,11 +10,15 @@ import styles from './SelectedTravelSpots.module.css';
 type SelectedTravelSpotsProps = {
   selectedSpots: TravelSpot[];
   setTravelSpots: React.Dispatch<React.SetStateAction<TravelSpot[]>>;
+  onBackPage?: () => void;
+  buttonType?: 'travelSpotList' | 'sightseeingMap';
 };
 
 const SelectedTravelSpots: React.FC<SelectedTravelSpotsProps> = ({
   selectedSpots,
   setTravelSpots,
+  onBackPage,
+  buttonType = 'travelSpotList',
 }) => {
   const router = useRouter();
 
@@ -82,15 +86,23 @@ const SelectedTravelSpots: React.FC<SelectedTravelSpotsProps> = ({
   return (
     <div className={styles.main}>
       <h2>選択されたスポット</h2>
-      <div className={styles.buttonGroup}>
-        <button onClick={handleDecide} className={styles.button}>
-          行き先決定
-        </button>
+      {buttonType === 'sightseeingMap' ? (
+        <div className={styles.backButton}>
+          <button onClick={onBackPage} className={styles.button}>
+            戻る
+          </button>
+        </div>
+      ) : (
+        <div className={styles.buttonGroup}>
+          <button onClick={handleDecide} className={styles.button}>
+            行き先決定
+          </button>
 
-        <button onClick={handleReset} className={styles.button}>
-          リセット
-        </button>
-      </div>
+          <button onClick={handleReset} className={styles.button}>
+            リセット
+          </button>
+        </div>
+      )}
       <div className={styles.listContainer}>
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
           <SortableContext items={selectedSpots.map((spot) => spot.name)}>

--- a/client/features/map/MapBoxMap.tsx
+++ b/client/features/map/MapBoxMap.tsx
@@ -14,11 +14,6 @@ const MapBoxMap = ({ allDestinationSpots, currentLocation }: MapBoxMapProps) => 
   const currentLocationElement = useRef<HTMLDivElement | null>(null);
   useMap(allDestinationSpots, currentLocation, mapContainer, markerRef, currentLocationElement);
 
-  // const router = useRouter();
-  // const onBackPage = () => {
-  //   router.push('/travelSpotList');
-  // };
-
   return (
     <div>
       <div ref={mapContainer} className={styles.map} />

--- a/client/pages/sightseeingMap/index.page.tsx
+++ b/client/pages/sightseeingMap/index.page.tsx
@@ -4,6 +4,7 @@ import { Loading } from 'components/loading/Loading';
 import SelectedTravelSpots from 'components/selectedTravelSpots/SelectedTravelSpots';
 import MapBoxMap from 'features/map/MapBoxMap';
 import { useAtom } from 'jotai';
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { getSelectedTravelSpots } from 'utils/selectedTravelSpots';
 import { travelSpotsAtom } from 'utils/travelSpotsAtom';
@@ -21,6 +22,13 @@ const SightseeingMap = () => {
     });
   }, []);
 
+  const router = useRouter();
+  const onBackPage = () => {
+    router.push('/travelSpotList');
+  };
+
+  const buttonType = router.pathname === '/sightseeingMap' ? 'sightseeingMap' : 'travelSpotList';
+
   if (!currentLocation) {
     return <Loading visible />;
   }
@@ -29,9 +37,13 @@ const SightseeingMap = () => {
     <div className={styles.container}>
       <Header />
       <div className={styles.main}>
-        <SelectedTravelSpots selectedSpots={selectedSpots} setTravelSpots={setTravelSpots} />
+        <SelectedTravelSpots
+          selectedSpots={selectedSpots}
+          setTravelSpots={setTravelSpots}
+          buttonType={buttonType}
+          onBackPage={onBackPage}
+        />
         <MapBoxMap allDestinationSpots={selectedSpots} currentLocation={currentLocation} />
-        {/* <button onClick={onBackPage}>戻る</button> */}
       </div>
     </div>
   );


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容の説明を記載してください。
-->
travelSpotListとsightseeingMapページでのボタンの表示の仕方を変えた

## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。
- 変更点 1
- 変更点 2
- 変更点 3 -->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くとPRがマージされた際に自動的にIssueが閉じられます。
（例）
ref #0
close #0
-->

## スクリーンショット・動画など
![image](https://github.com/user-attachments/assets/d8a2eaa4-ae09-42fa-b478-9f9891810077)
![image](https://github.com/user-attachments/assets/65459bdb-1939-4ba0-98c0-bdb684877704)

<!--
UIを実装・変更した際は、動画・スクリーンショットがあると助かります。
-->

## その他
