### PR TITLE
デザインの調整

### DIFF
--- a/client/components/header/header.module.css
+++ b/client/components/header/header.module.css
@@ -4,7 +4,7 @@
   width: 100%;
   height: 60px;
   background-color: #fff;
-  border-bottom: 1px solid var(--border-color-default);
+  border-bottom: 2px solid var(--border-color-default);
 }
 
 .main {
@@ -17,10 +17,12 @@
 }
 
 .appName {
-  font-size: calc(100% + 1.1vw);
+  font-family: 'Rampart One', sans-serif;
+  font-size: calc(100% + 1.2vw);
+  font-style: normal;
   font-weight: bold;
   color: var(--font-color-default);
-  letter-spacing: 0.18em;
+  letter-spacing: 0.14em;
   cursor: pointer;
 }
 

--- a/client/components/selectedTravelSpots/SelectedTravelSpots.module.css
+++ b/client/components/selectedTravelSpots/SelectedTravelSpots.module.css
@@ -18,26 +18,28 @@
 }
 
 .listContainer {
-  display: flex;
-  flex-direction: column;
-  align-items: center; /* 中央揃え */
-  text-align: center;
+  padding: 10px;
 }
 
 .listItem {
-  display: flex;
-  align-items: center;
-  justify-content: center; /* 中央揃え */
   margin-bottom: 10px;
+  list-style: none;
+  transition: transform 0.2s ease;
+}
+
+.listItem:hover {
+  cursor: move;
+  background-color: rgb(233 84 100 / 10%);
+  transform: scale(1.05);
 }
 
 .listTitle {
-  margin-right: 10px;
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  margin: 0;
   font-weight: bold;
-}
-
-.listDescription {
-  margin-right: 10px;
+  border-radius: 30px; /* 角を丸く */
 }
 
 .buttonGroup {

--- a/client/components/selectedTravelSpots/SelectedTravelSpots.tsx
+++ b/client/components/selectedTravelSpots/SelectedTravelSpots.tsx
@@ -74,9 +74,10 @@ const SelectedTravelSpots: React.FC<SelectedTravelSpotsProps> = ({
 
     return (
       <li ref={setNodeRef} style={style} {...attributes} {...listeners} className={styles.listItem}>
-        <p className={styles.listTitle}>
-          {spot.index !== null ? spot.index + 1 : ''}.{spot.name}
-        </p>
+        <h3 className={styles.listTitle}>
+          {spot.index !== null ? `${spot.index + 1}. ` : ''}
+          {spot.name}
+        </h3>
       </li>
     );
   };

--- a/client/pages/_document.page.tsx
+++ b/client/pages/_document.page.tsx
@@ -8,6 +8,10 @@ function Document() {
       <Head>
         <meta name="description" content={APP_NAME} />
         <link rel="icon" href={staticPath.favicon_png} />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Mochiy+Pop+One&family=Rampart+One&display=swap"
+          rel="stylesheet"
+        />
       </Head>
       <body>
         <Main />

--- a/client/pages/index.module.css
+++ b/client/pages/index.module.css
@@ -19,17 +19,6 @@
   margin-top: 60px;
 }
 
-.titleContainer {
-  display: flex;
-  justify-content: center;
-  margin-top: 5%;
-}
-
-.title {
-  font-size: calc(12px + 3vw);
-  font-weight: bold;
-}
-
 .imageBox {
   display: flex;
   justify-content: center;
@@ -45,8 +34,6 @@
   display: flex;
   justify-content: center;
   width: calc(100vw - 20vw);
-
-  /* max-width: 800px; */
   height: calc(100vh - 70vh);
   max-height: 400px;
 }

--- a/client/pages/index.page.tsx
+++ b/client/pages/index.page.tsx
@@ -29,10 +29,6 @@ const TravelDestination = () => {
       <Loading visible={isLoading} />
       <Header />
       <div className={styles.main}>
-        <div className={styles.titleContainer}>
-          <div className={styles.title}>TravelDestination</div>
-        </div>
-
         <div className={styles.imageBox}>
           <img
             src={staticPath.images.undraw_World_re_768g_png}

--- a/client/pages/travelSpotList/index.module.css
+++ b/client/pages/travelSpotList/index.module.css
@@ -77,6 +77,11 @@
     border-color 0.3s;
 }
 
+.listItem:hover {
+  background-color: #f0f0f0;
+  border-color: #aaa;
+}
+
 .selected {
   border: 2px solid var(--font-color-default);
 }
@@ -84,8 +89,10 @@
 .imagesBox {
   position: relative;
   width: 100%;
-  height: 0;
-  padding-bottom: 56.25%; /* 16:9 aspect ratio */
+  height: 150px;
+  padding-bottom: 56.25%;
+  margin-bottom: 10px;
+  overflow: hidden;
 }
 
 .images {
@@ -94,6 +101,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  padding: 2%;
   object-fit: cover;
 }
 
@@ -110,7 +118,12 @@
 }
 
 .listDescription {
+  flex-grow: 1;
+  margin-bottom: 10px;
+  overflow: hidden;
   color: gray;
+  text-align: justify;
+  text-overflow: ellipsis;
 }
 
 .listCategory {

--- a/client/pages/travelSpotList/index.page.tsx
+++ b/client/pages/travelSpotList/index.page.tsx
@@ -9,23 +9,9 @@ const TravelSpotList = () => {
   const [travelSpots, setTravelSpots] = useAtom<TravelSpot[]>(travelSpotsAtom);
   const selectedSpots = getSelectedTravelSpots(travelSpots);
 
-  // const handleCheckboxChange = (index: number) => {
-  //   setTravelSpots((prevTravelSpots) =>
-  //     prevTravelSpots.map((spot, i) =>
-  //       i === index
-  //         ? {
-  //             ...spot,
-  //             isSelected: !spot.isSelected,
-  //             index: !spot.isSelected ? prevTravelSpots.filter((s) => s.isSelected).length : null,
-  //           }
-  //         : spot,
-  //     ),
-  //   );
-  // };
-
   const handleItemClick = (index: number) => {
-    setTravelSpots((prevTravelSpots) =>
-      prevTravelSpots.map((spot, i) =>
+    setTravelSpots((prevTravelSpots) => {
+      const updatedSpots = prevTravelSpots.map((spot, i) =>
         i === index
           ? {
               ...spot,
@@ -33,14 +19,16 @@ const TravelSpotList = () => {
               index: !spot.isSelected ? prevTravelSpots.filter((s) => s.isSelected).length : null,
             }
           : spot,
-      ),
-    );
-  };
-  const truncateDescription = (description: string) => {
-    const maxLength = window.innerWidth <= 800 ? 50 : 800;
-    return description.length > maxLength
-      ? `${description.substring(0, maxLength)}...`
-      : description;
+      );
+
+      // インデックスが null の場合に再計算
+      const selectedSpots = updatedSpots.filter((spot) => spot.isSelected);
+      selectedSpots.forEach((spot, idx) => {
+        spot.index = idx;
+      });
+
+      return updatedSpots;
+    });
   };
   return (
     <div className={styles.container}>
@@ -53,7 +41,6 @@ const TravelSpotList = () => {
 
           <ul className={styles.list}>
             {travelSpots.map((spot, index) => (
-              // <li key={index} className={styles.listItem}>
               <li
                 key={index}
                 className={`${styles.listItem} ${spot.isSelected ? styles.selected : ''}`}
@@ -66,13 +53,8 @@ const TravelSpotList = () => {
                     <p>写真なし</p>
                   )}
                 </div>
-                {/* <input
-                    type="checkbox"
-                    onChange={() => handleCheckboxChange(index)}
-                    checked={spot.isSelected}
-                  /> */}
                 <h2 className={styles.listTitle}>{spot.name}</h2>
-                <p className={styles.listDescription}>{truncateDescription(spot.description)}</p>
+                <p className={styles.listDescription}>{spot.description}</p>
                 <p className={styles.listCategory}>カテゴリ：{spot.categories}</p>
               </li>
             ))}


### PR DESCRIPTION
## 内容

デザインの調整
ロゴはこれのRampart Oneを使った
https://fonts.google.com/selection/embed

## 変更点

1. headerのロゴ修正
2. headerのboader-bottomを1pxから2pxに
3. トップページのTravelDestinationの文字削除
4. /travelSpotListの要素が押せることがわかるようにホバーをつけた
5. selectedTravelSpotの要素が動かせのがわかるようににホバーをつけた
6. isSelectedが外れた場合に他の選択されたスポットのインデックスを更新
7. TravelSpotListの要素がズレるのを修正


## 関連 Issue

## スクリーンショット・動画など
<img width="1511" alt="スクリーンショット 2024-07-20 17 17 17" src="https://github.com/user-attachments/assets/2f934e52-21de-48e5-a1c6-8c6b8bea9cfc">



https://github.com/user-attachments/assets/311933cf-4e9b-4b9b-b2cf-46ebb9ce3bfa



## その他

